### PR TITLE
Set restricted by default

### DIFF
--- a/src/DssVest.sol
+++ b/src/DssVest.sol
@@ -204,7 +204,7 @@ abstract contract DssVest is ERC2771Context {
             tot: toUint128(_tot),
             rxd: 0,
             mgr: _mgr,
-            res: 0
+            res: 1
         });
         emit Init(id, _usr);
     }

--- a/src/DssVest.t.sol
+++ b/src/DssVest.t.sol
@@ -537,7 +537,8 @@ contract DssVestTest is DSTest {
     function testUnRestrictedVest() public {
         ThirdPartyVest alice = new ThirdPartyVest();
         uint256 id = mVest.create(address(this), 100 * days_vest, block.timestamp, 100 days, 0 days, address(0));
-
+        mVest.unrestrict(id);
+        
         hevm.warp(block.timestamp + 10 days);
 
         (address usr, uint48 bgn, uint48 clf, uint48 fin, address mgr,, uint128 tot, uint128 rxd) = mVest.awards(id);
@@ -593,6 +594,10 @@ contract DssVestTest is DSTest {
         User bob = new User();
         uint256 id = mVest.create(address(bob), 100 * days_vest, block.timestamp, 100 days, 0 days, address(0));
 
+        assertEq(mVest.res(id), 1);
+
+        bob.unrestrict(address(mVest), id);
+        
         assertEq(mVest.res(id), 0);
 
         bob.restrict(address(mVest), id);
@@ -825,6 +830,9 @@ contract DssVestTest is DSTest {
             0,
             address(0)
         );
+
+        usr.unrestrict(address(tVest), id);
+
 
         assertTrue(tVest.valid(id));
         hevm.warp(block.timestamp + 1 days);

--- a/src/DssVestERC2771.t.sol
+++ b/src/DssVestERC2771.t.sol
@@ -396,6 +396,7 @@ contract DssVestERC2771Test is Test {
         hevm.warp(block.timestamp + 999 days);
         assertEq(mVest.unpaid(id), 2 * days_vest);
         assertEq(mVest.accrued(id), 4 * days_vest);
+        vm.prank(usrAddress);
         mVest.vest(id); // user collects at some future time
         assertTrue(!mVest.valid(id));
         assertEq(gem.balanceOf(usrAddress), 4 * days_vest);


### PR DESCRIPTION
because it is better for the user to be able to decide when to receive tokens