### PR TITLE
wrap add, div, mul in unchecked

### DIFF
--- a/src/DssVest.sol
+++ b/src/DssVest.sol
@@ -159,13 +159,19 @@ abstract contract DssVest is ERC2771Context {
         z = x > y ? y : x;
     }
     function add(uint256 x, uint256 y) internal pure returns (uint256 z) {
-        require((z = x + y) >= x, "DssVest/add-overflow");
+        unchecked {
+            require((z = x + y) >= x, "DssVest/add-overflow");
+        }
     }
     function sub(uint256 x, uint256 y) internal pure returns (uint256 z) {
-        require((z = x - y) <= x, "DssVest/sub-underflow");
+        unchecked {
+            require((z = x - y) <= x, "DssVest/sub-underflow");
+        }
     }
     function mul(uint256 x, uint256 y) internal pure returns (uint256 z) {
-        require(y == 0 || (z = x * y) / y == x, "DssVest/mul-overflow");
+        unchecked {
+            require(y == 0 || (z = x * y) / y == x, "DssVest/mul-overflow");
+        }
     }
     function toUint48(uint256 x) internal pure returns (uint48 z) {
         require((z = uint48(x)) == x, "DssVest/uint48-overflow");


### PR DESCRIPTION
Run the checks unchecked to generate the same revert messages as in the original version.

> Recommendation

> We recommend wrapping the bodies of the functions add , sub , and mul in an unchecked { ... } block each to stay as close as
> possible to the original behavior of the contract, i.e., get the original revert messages instead of a panic in case of
> over-/under