### PR TITLE
Fix comment

### DIFF
--- a/src/DssVest.sol
+++ b/src/DssVest.sol
@@ -175,7 +175,7 @@ abstract contract DssVest is ERC2771Context {
     }
 
     /**
-        @dev Govanance adds a vesting contract
+        @dev Governance adds a vesting contract
         @param _usr The recipient of the reward
         @param _tot The total amount of the vest
         @param _bgn The starting timestamp of the vest

--- a/src/DssVest.sol
+++ b/src/DssVest.sol
@@ -283,7 +283,7 @@ abstract contract DssVest is ERC2771Context {
     }
 
     /**
-        @dev amount of tokens accrued, not accounting for tokens paid
+        @dev amount of tokens accrued, but not paid yet
         @param _time The timestamp to perform the calculation
         @param _bgn  The start time of the contract
         @param _clf  The timestamp of the cliff


### PR DESCRIPTION
Comment was unclear. It now describes the function better.

> Indeed, the function returns an amount of tokens that accounts for tokens already paid (it substracts _rxd
from the accrued amount), but the NatSpec comment states it does not.