### PR TITLE
define factory as library instead of contract

### DIFF
--- a/src/Factory.sol
+++ b/src/Factory.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.17;
 
 import {DssVestMintable} from "./DssVest.sol";
 
-contract DssVestNaiveFactory {
+library DssVestNaiveFactory {
 
     event DssVestMintableCreated(address dssVestMintable, address companyAdminAddress);
 

--- a/test/DssVestDemo.t.sol
+++ b/test/DssVestDemo.t.sol
@@ -50,10 +50,6 @@ contract DssVestDemo is Test {
     function setUp() public {
 
         vm.warp(60 * 365 days); // in local testing, the time would start at 1. This causes problems with the vesting contract. So we warp to 60 years.
-
-        // deploy factory contract
-        DssVestNaiveFactory factory = new DssVestNaiveFactory();
-
         // deploy tokenize.it platform and company token
         vm.startPrank(platformAdminAddress);
         AllowList allowList = new AllowList();
@@ -80,7 +76,7 @@ contract DssVestDemo is Test {
 
 
         // deploy vesting contract with any wallet, setting forwarder, token and admin
-        mVest = DssVestMintable(factory.createDssVestMintable(address(forwarder), address(companyToken), companyAdminAddress));
+        mVest = DssVestMintable(DssVestNaiveFactory.createDssVestMintable(address(forwarder), address(companyToken), companyAdminAddress));
 
         // configure vesting contract
         vm.startPrank(companyAdminAddress);

--- a/test/Factory.t.sol
+++ b/test/Factory.t.sol
@@ -82,19 +82,15 @@ contract DssVestFactoryDemo is Test {
             "COMPT"
         );
         vm.stopPrank();
-
-        // deploy factory
-        DssVestNaiveFactory factory = new DssVestNaiveFactory();
-
         // Deploy instance
-        mVest = DssVestMintable(factory.createDssVestMintable(address(forwarder), address(companyToken), companyAdminAddress));
+        mVest = DssVestMintable(DssVestNaiveFactory.createDssVestMintable(address(forwarder), address(companyToken), companyAdminAddress));
 
         require(mVest.isTrustedForwarder(address(forwarder)), "Forwarder not trusted");
         require(address(mVest.gem()) == address(companyToken), "Token not set");
         require(mVest.wards(companyAdminAddress) == 1, "Company admin is not a ward");
         require(mVest.wards(address(this)) == 0, "Msg.sender is a ward");
         
-        console.log("factory address: ", address(factory));
+        console.log("DssVestNaiveFactory address: ", address(DssVestNaiveFactory));
         console.log("clone address: ", address(mVest));
 
         // initialize vesting contract 
@@ -110,12 +106,10 @@ contract DssVestFactoryDemo is Test {
     function testNoWrongWardslocal() public {
 
         vm.startPrank(platformAdminAddress);
-        // Deploy instance
-        DssVestNaiveFactory factory = new DssVestNaiveFactory();
-        mVest = DssVestMintable(factory.createDssVestMintable(address(forwarder), address(companyToken), companyAdminAddress));
+        mVest = DssVestMintable(DssVestNaiveFactory.createDssVestMintable(address(forwarder), address(companyToken), companyAdminAddress));
         vm.stopPrank();
 
-        console.log("factory address: ", address(factory));
+        console.log("DssVestNaiveFactory address: ", address(DssVestNaiveFactory));
         console.log("companyAdminAddress: ", companyAdminAddress);
         console.log("test account address: ", address(this));
         console.log("platformAdminAddress: ", platformAdminAddress);
@@ -123,7 +117,7 @@ contract DssVestFactoryDemo is Test {
         require(mVest.isTrustedForwarder(address(forwarder)), "Forwarder not trusted");
         require(address(mVest.gem()) == address(companyToken), "Token not set");
         require(mVest.wards(companyAdminAddress) == 1, "Company admin is not a ward");
-        require(mVest.wards(address(factory)) == 0, "Factory is a ward");
+        require(mVest.wards(address(DssVestNaiveFactory)) == 0, "Factory is a ward");
         require(mVest.wards(platformAdminAddress) == 0, "Platform is a ward");
         require(mVest.wards(address(this)) == 0, "Test account is a ward");
         


### PR DESCRIPTION
It is easy enough to use the factory as `library` instead of `contract`. But it appears etherscan exposes the write functions only for contracts, because it says "no write functions" for the library:
- library: no write functions
  - https://goerli.etherscan.io/address/0xb0e8725964154b11f4385e59bd40fcd0bb97c083#writeContract
- contract: has write function 
  - https://goerli.etherscan.io/address/0x1f23e2b07c98f3ff91d51e8720b173e77d59bcec#writeContract

I am unsure what to make of that. 