### PR TITLE
Update echidna storage slots

### DIFF
--- a/echidna/DssVestMintableEchidnaTest.sol
+++ b/echidna/DssVestMintableEchidnaTest.sol
@@ -417,8 +417,8 @@ contract DssVestMintableEchidnaTest {
     }
     function _mutusr(uint256 id) internal {
         address usr = mVest.usr(id) == address(this) ? address(0) : address(this);
-        // Set DssVestMintable awards slot n. 1 (clf, bgn, usr) to override awards(id).usr with address(this)
-        hevm.store(address(mVest), keccak256(abi.encode(uint256(id), uint256(1))), bytesToBytes32(abi.encodePacked(uint48(mVest.clf(id)), uint48(mVest.bgn(id)), usr)));
+        // Set DssVestMintable awards slot n. 2 (clf, bgn, usr) to override awards(id).usr with address(this)
+        hevm.store(address(mVest), keccak256(abi.encode(uint256(id), uint256(2))), bytesToBytes32(abi.encodePacked(uint48(mVest.clf(id)), uint48(mVest.bgn(id)), usr)));
         assert(mVest.usr(id) == usr);
     }
     function mutcap(uint256 bump) private clock(90 days) {

--- a/echidna/DssVestMintableEchidnaTest.sol
+++ b/echidna/DssVestMintableEchidnaTest.sol
@@ -19,6 +19,11 @@ contract DssVestMintableEchidnaTest {
     uint256 internal constant  YEAR = 365 days;
     uint256 internal constant  MIN  = 500;      // Initial cap amount
     uint256 internal constant  MAX  = 2000;     // Max cap amount
+    uint256 internal constant  WARDS_MEMORY_SLOT    = 1;
+    uint256 internal constant  AWARDS_MEMORY_SLOT   = 2;
+    uint256 internal constant  CAP_MEMORY_SLOT      = 3;
+    uint256 internal constant  IDS_MEMORY_SLOT      = 4;
+    uint256 internal constant  LOCK_MEMORY_SLOT     = 5;
     uint256 internal immutable salt;            // initialTimestamp
 
 
@@ -127,7 +132,7 @@ contract DssVestMintableEchidnaTest {
             assert(mVest.commitments(bch) == false); // commitment must be false after
             _mutusr(id);
         } catch Error(string memory errmsg) {
-            bytes32 mLocked = hevm.load(address(mVest), bytes32(uint256(4)));      // Load memory slot 0x4
+            bytes32 mLocked = hevm.load(address(mVest), bytes32(uint256(LOCK_MEMORY_SLOT)));      // Load memory slot containing locked flag
             assert(
                 uint256(mLocked) == 1                                    && cmpStr(errmsg, "DssVest/system-locked")        ||
                 // authorization is not required for this function
@@ -173,7 +178,7 @@ contract DssVestMintableEchidnaTest {
             assert(mVest.res(id) == 1);
             _mutusr(id);
         } catch Error(string memory errmsg) {
-            bytes32 mLocked = hevm.load(address(mVest), bytes32(uint256(4)));      // Load memory slot 0x4
+            bytes32 mLocked = hevm.load(address(mVest), bytes32(uint256(LOCK_MEMORY_SLOT)));      // Load memory slot containing locked flag
             assert(
                 uint256(mLocked) == 1                                    && cmpStr(errmsg, "DssVest/system-locked")        ||
                 mVest.wards(address(this)) == 0                          && cmpStr(errmsg, "DssVest/not-authorized")       ||
@@ -234,7 +239,7 @@ contract DssVestMintableEchidnaTest {
                 assert(gem.balanceOf(award.usr) == _add(usrBalanceBefore, unpaidAmt));
             }
         } catch Error(string memory errmsg) {
-            bytes32 mLocked = hevm.load(address(mVest), bytes32(uint256(4)));      // Load memory slot 0x4
+            bytes32 mLocked = hevm.load(address(mVest), bytes32(uint256(LOCK_MEMORY_SLOT)));      // Load memory slot containing locked flag
             assert(
                 uint256(mLocked) == 1                                              && cmpStr(errmsg, "DssVest/system-locked")       ||
                 award.usr == address(0)                                            && cmpStr(errmsg, "DssVest/invalid-award")       ||
@@ -283,7 +288,7 @@ contract DssVestMintableEchidnaTest {
                 assert(gem.balanceOf(award.usr) == _add(usrBalanceBefore, amt));
             }
         } catch Error(string memory errmsg) {
-            bytes32 mLocked = hevm.load(address(mVest), bytes32(uint256(4)));      // Load memory slot 0x4
+            bytes32 mLocked = hevm.load(address(mVest), bytes32(uint256(LOCK_MEMORY_SLOT)));      // Load memory slot containing locked flag
             assert(
                 uint256(mLocked) == 1                                              && cmpStr(errmsg, "DssVest/system-locked")       ||
                 award.usr == address(0)                                            && cmpStr(errmsg, "DssVest/invalid-award")       ||
@@ -307,7 +312,7 @@ contract DssVestMintableEchidnaTest {
         try mVest.restrict(id) {
             assert(mVest.res(id) == 1);
         } catch Error(string memory errmsg) {
-            bytes32 mLocked = hevm.load(address(mVest), bytes32(uint256(4)));      // Load memory slot 0x4
+            bytes32 mLocked = hevm.load(address(mVest), bytes32(uint256(LOCK_MEMORY_SLOT)));      // Load memory slot containing locked flag
             assert(
                 uint256(mLocked) == 1           && cmpStr(errmsg, "DssVest/system-locked") ||
                 mVest.usr(id) == address(0)     && cmpStr(errmsg, "DssVest/invalid-award") ||
@@ -324,7 +329,7 @@ contract DssVestMintableEchidnaTest {
         try mVest.unrestrict(id) {
             assert(mVest.res(id) == 0);
         } catch Error(string memory errmsg) {
-            bytes32 mLocked = hevm.load(address(mVest), bytes32(uint256(4)));      // Load memory slot 0x4
+            bytes32 mLocked = hevm.load(address(mVest), bytes32(uint256(LOCK_MEMORY_SLOT)));      // Load memory slot containing locked flag
             assert(
                uint256(mLocked) == 1           && cmpStr(errmsg, "DssVest/system-locked") ||
                mVest.usr(id) == address(0)     && cmpStr(errmsg, "DssVest/invalid-award") ||
@@ -359,7 +364,7 @@ contract DssVestMintableEchidnaTest {
                 }
             }
         } catch Error(string memory errmsg) {
-            bytes32 mLocked = hevm.load(address(mVest), bytes32(uint256(4)));      // Load memory slot 0x4
+            bytes32 mLocked = hevm.load(address(mVest), bytes32(uint256(LOCK_MEMORY_SLOT)));      // Load memory slot containing locked flag
             assert(
                 uint256(mLocked) == 1                                              && cmpStr(errmsg, "DssVest/system-locked")    ||
                 mVest.wards(address(this)) == 0 && mgr != address(this)            && cmpStr(errmsg, "DssVest/not-authorized")   ||
@@ -383,7 +388,7 @@ contract DssVestMintableEchidnaTest {
             assert(mVest.usr(id) == dst);
             _mutusr(id);
         } catch Error(string memory errmsg) {
-            bytes32 mLocked = hevm.load(address(mVest), bytes32(uint256(4)));      // Load memory slot 0x4
+            bytes32 mLocked = hevm.load(address(mVest), bytes32(uint256(LOCK_MEMORY_SLOT)));      // Load memory slot containing locked flag
             assert(
                 uint256(mLocked) == 1          && cmpStr(errmsg, "DssVest/system-locked")       ||
                 mVest.usr(id) != address(this) && cmpStr(errmsg, "DssVest/only-user-can-move")  ||
@@ -397,17 +402,17 @@ contract DssVestMintableEchidnaTest {
     // --- Time-Based Fuzz Mutations ---
 
     function mutlock() private clock(1 hours) {
-        bytes32 mLocked = hevm.load(address(mVest), bytes32(uint256(4)));          // Load memory slot 0x4
+        bytes32 mLocked = hevm.load(address(mVest), bytes32(uint256(LOCK_MEMORY_SLOT)));          // Load memory slot containing locked flag
         uint256 locked = uint256(mLocked) == 0 ? 1 : 0;
-        // Set DssVestMintable locked slot n. 4 to override 0 with 1 and vice versa
-        hevm.store(address(mVest), bytes32(uint256(4)), bytes32(uint256(locked)));
-        mLocked = hevm.load(address(mVest), bytes32(uint256(4)));
+        // Set DssVestMintable locked slot n. 5 to override 0 with 1 and vice versa
+        hevm.store(address(mVest), bytes32(uint256(LOCK_MEMORY_SLOT)), bytes32(uint256(locked)));
+        mLocked = hevm.load(address(mVest), bytes32(uint256(LOCK_MEMORY_SLOT)));
         assert(uint256(mLocked) == locked);
     }
     function mutauth() private clock(1 hours) {
         uint256 wards = mVest.wards(address(this)) == 1 ? 0 : 1;
-        // Set DssVestMintable wards slot n. 0 to override address(this) wards
-        hevm.store(address(mVest), keccak256(abi.encode(address(this), uint256(0))), bytes32(uint256(wards)));
+        // Set DssVestMintable wards slot n. 1 to override address(this) wards
+        hevm.store(address(mVest), keccak256(abi.encode(address(this), uint256(WARDS_MEMORY_SLOT))), bytes32(uint256(wards)));
         assert(mVest.wards(address(this)) == wards);
     }
     function mutusr(uint256 id) private clock(1 days) {
@@ -418,15 +423,15 @@ contract DssVestMintableEchidnaTest {
     function _mutusr(uint256 id) internal {
         address usr = mVest.usr(id) == address(this) ? address(0) : address(this);
         // Set DssVestMintable awards slot n. 2 (clf, bgn, usr) to override awards(id).usr with address(this)
-        hevm.store(address(mVest), keccak256(abi.encode(uint256(id), uint256(2))), bytesToBytes32(abi.encodePacked(uint48(mVest.clf(id)), uint48(mVest.bgn(id)), usr)));
+        hevm.store(address(mVest), keccak256(abi.encode(uint256(id), uint256(AWARDS_MEMORY_SLOT))), bytesToBytes32(abi.encodePacked(uint48(mVest.clf(id)), uint48(mVest.bgn(id)), usr)));
         assert(mVest.usr(id) == usr);
     }
     function mutcap(uint256 bump) private clock(90 days) {
         bump %= MAX;
         if (bump == 0) return;
         uint256 data = bump > MIN ? bump * WAD / YEAR : MIN * WAD / YEAR;
-        // Set DssVestMintable cap slot n. 2 to override cap with data
-        hevm.store(address(mVest), bytes32(uint256(2)), bytes32(uint256(data)));
+        // Set DssVestMintable cap slot n. 3 to override cap with data
+        hevm.store(address(mVest), bytes32(uint256(CAP_MEMORY_SLOT)), bytes32(uint256(data)));
         assert(mVest.cap() == data);
     }
 }

--- a/echidna/DssVestSuckableEchidnaTest.sol
+++ b/echidna/DssVestSuckableEchidnaTest.sol
@@ -32,6 +32,11 @@ contract DssVestSuckableEchidnaTest {
     uint256 internal constant  TIME     = 30 days;
     uint256 internal constant  MIN      = THOUSAND; // Initial cap amount
     uint256 internal constant  MAX      = MILLION;  // Max cap amount
+    uint256 internal constant  WARDS_MEMORY_SLOT    = 1;
+    uint256 internal constant  AWARDS_MEMORY_SLOT   = 2;
+    uint256 internal constant  CAP_MEMORY_SLOT      = 3;
+    uint256 internal constant  IDS_MEMORY_SLOT      = 4;
+    uint256 internal constant  LOCK_MEMORY_SLOT     = 5;
     uint256 internal immutable salt;                // initialTimestamp
 
     // Clock
@@ -150,9 +155,9 @@ contract DssVestSuckableEchidnaTest {
             assert(sVest.commitments(bch) == false); // commitment must be false after
             _mutusr(id);
         } catch Error(string memory errmsg) {
-            bytes32 mLocked = hevm.load(address(sVest), bytes32(uint256(4)));      // Load memory slot 0x4
+            bytes32 sLocked = hevm.load(address(sVest), bytes32(uint256(LOCK_MEMORY_SLOT)));      // Load memory slot containing locked flag
             assert(
-                uint256(mLocked) == 1                                    && cmpStr(errmsg, "DssVest/system-locked")        ||
+                uint256(sLocked) == 1                                    && cmpStr(errmsg, "DssVest/system-locked")        ||
                 // authorization is not required for this function
                 // sVest.wards(address(this)) == 0                          && cmpStr(errmsg, "DssVest/not-authorized")       ||
                 usr == address(0)                                        && cmpStr(errmsg, "DssVest/invalid-user")         ||
@@ -196,7 +201,7 @@ contract DssVestSuckableEchidnaTest {
             assert(sVest.res(id) == 1);
             _mutusr(id);
         } catch Error(string memory errmsg) {
-            bytes32 sLocked = hevm.load(address(sVest), bytes32(uint256(4)));      // Load memory slot 0x4
+            bytes32 sLocked = hevm.load(address(sVest), bytes32(uint256(LOCK_MEMORY_SLOT)));      // Load memory slot containing locked flag
             assert(
                 uint256(sLocked) == 1                                    && cmpStr(errmsg, "DssVest/system-locked")        ||
                 sVest.wards(address(this)) == 0                          && cmpStr(errmsg, "DssVest/not-authorized")       ||
@@ -260,7 +265,7 @@ contract DssVestSuckableEchidnaTest {
                 assert(dai.balanceOf(award.usr) == _add(usrBalanceBefore, unpaidAmt));
             }
         } catch Error(string memory errmsg) {
-            bytes32 sLocked = hevm.load(address(sVest), bytes32(uint256(4)));      // Load memory slot 0x4
+            bytes32 sLocked = hevm.load(address(sVest), bytes32(uint256(LOCK_MEMORY_SLOT)));      // Load memory slot containing locked flag
             assert(
                 uint256(sLocked) == 1                                              && cmpStr(errmsg, "DssVest/system-locked")        ||
                 award.usr == address(0)                                            && cmpStr(errmsg, "DssVest/invalid-award")        ||
@@ -323,7 +328,7 @@ contract DssVestSuckableEchidnaTest {
                 assert(dai.balanceOf(award.usr) == _add(usrBalanceBefore, amt));
             }
         } catch Error(string memory errmsg) {
-            bytes32 sLocked = hevm.load(address(sVest), bytes32(uint256(4)));      // Load memory slot 0x4
+            bytes32 sLocked = hevm.load(address(sVest), bytes32(uint256(LOCK_MEMORY_SLOT)));      // Load memory slot containing locked flag
             assert(
                 uint256(sLocked) == 1                                              && cmpStr(errmsg, "DssVest/system-locked")        ||
                 award.usr == address(0)                                            && cmpStr(errmsg, "DssVest/invalid-award")        ||
@@ -358,7 +363,7 @@ contract DssVestSuckableEchidnaTest {
         try sVest.restrict(id) {
             assert(sVest.res(id) == 1);
         } catch Error(string memory errmsg) {
-            bytes32 sLocked = hevm.load(address(sVest), bytes32(uint256(4)));      // Load memory slot 0x4
+            bytes32 sLocked = hevm.load(address(sVest), bytes32(uint256(LOCK_MEMORY_SLOT)));      // Load memory slot containing locked flag
             assert(
                 uint256(sLocked) == 1           && cmpStr(errmsg, "DssVest/system-locked") ||
                 sVest.usr(id) == address(0)     && cmpStr(errmsg, "DssVest/invalid-award") ||
@@ -375,7 +380,7 @@ contract DssVestSuckableEchidnaTest {
         try sVest.unrestrict(id) {
             assert(sVest.res(id) == 0);
         } catch Error(string memory errmsg) {
-            bytes32 sLocked = hevm.load(address(sVest), bytes32(uint256(4)));      // Load memory slot 0x4
+            bytes32 sLocked = hevm.load(address(sVest), bytes32(uint256(LOCK_MEMORY_SLOT)));      // Load memory slot containing locked flag
             assert(
                uint256(sLocked) == 1           && cmpStr(errmsg, "DssVest/system-locked") ||
                sVest.usr(id) == address(0)     && cmpStr(errmsg, "DssVest/invalid-award") ||
@@ -410,7 +415,7 @@ contract DssVestSuckableEchidnaTest {
                 }
             }
         } catch Error(string memory errmsg) {
-            bytes32 sLocked = hevm.load(address(sVest), bytes32(uint256(4)));      // Load memory slot 0x4
+            bytes32 sLocked = hevm.load(address(sVest), bytes32(uint256(LOCK_MEMORY_SLOT)));      // Load memory slot containing locked flag
             assert(
                 uint256(sLocked) == 1                                              && cmpStr(errmsg, "DssVest/system-locked")    ||
                 sVest.wards(address(this)) == 0 && mgr != address(this)            && cmpStr(errmsg, "DssVest/not-authorized")   ||
@@ -434,7 +439,7 @@ contract DssVestSuckableEchidnaTest {
             assert(sVest.usr(id) == dst);
             _mutusr(id);
         } catch Error(string memory errmsg) {
-            bytes32 sLocked = hevm.load(address(sVest), bytes32(uint256(4)));      // Load memory slot 0x4
+            bytes32 sLocked = hevm.load(address(sVest), bytes32(uint256(LOCK_MEMORY_SLOT)));      // Load memory slot containing locked flag
             assert(
                 uint256(sLocked) == 1           && cmpStr(errmsg, "DssVest/system-locked")       ||
                 sVest.usr(id) != address(this)  && cmpStr(errmsg, "DssVest/only-user-can-move")  ||
@@ -448,17 +453,17 @@ contract DssVestSuckableEchidnaTest {
     // --- Time-Based Fuzz Mutations ---
 
     function mutlock() private clock(1 hours) {
-        bytes32 sLocked = hevm.load(address(sVest), bytes32(uint256(4)));          // Load memory slot 0x4
+        bytes32 sLocked = hevm.load(address(sVest), bytes32(uint256(LOCK_MEMORY_SLOT)));          // Load memory slot 0x4
         uint256 locked = uint256(sLocked) == 0 ? 1 : 0;
-        // Set DssVestSuckable locked slot n. 4 to override 0 with 1 and vice versa
-        hevm.store(address(sVest), bytes32(uint256(4)), bytes32(uint256(locked)));
-        sLocked = hevm.load(address(sVest), bytes32(uint256(4)));
+        // Set DssVestSuckable locked slot to override 0 with 1 and vice versa
+        hevm.store(address(sVest), bytes32(uint256(LOCK_MEMORY_SLOT)), bytes32(uint256(locked)));
+        sLocked = hevm.load(address(sVest), bytes32(uint256(LOCK_MEMORY_SLOT)));
         assert(uint256(sLocked) == locked);
     }
     function mutauth() private clock(1 hours) {
         uint256 wards = sVest.wards(address(this)) == 1 ? 0 : 1;
-        // Set DssVestSuckable wards slot n. 0 to override address(this) wards
-        hevm.store(address(sVest), keccak256(abi.encode(address(this), uint256(0))), bytes32(uint256(wards)));
+        // Set DssVestSuckable wards slot to override address(this) wards
+        hevm.store(address(sVest), keccak256(abi.encode(address(this), uint256(WARDS_MEMORY_SLOT))), bytes32(uint256(wards)));
         assert(sVest.wards(address(this)) == wards);
     }
     function mutlive() private clock(1 hours) {
@@ -474,16 +479,16 @@ contract DssVestSuckableEchidnaTest {
     }
     function _mutusr(uint256 id) internal {
         address usr = sVest.usr(id) == address(this) ? address(0) : address(this);
-        // Set DssVestSuckable awards slot n. 1 (clf, bgn, usr) to override awards(id).usr with address(this)
-        hevm.store(address(sVest), keccak256(abi.encode(uint256(id), uint256(1))), bytesToBytes32(abi.encodePacked(uint48(sVest.clf(id)), uint48(sVest.bgn(id)), usr)));
+        // Set DssVestSuckable awards slot (clf, bgn, usr) to override awards(id).usr with address(this)
+        hevm.store(address(sVest), keccak256(abi.encode(uint256(id), uint256(AWARDS_MEMORY_SLOT))), bytesToBytes32(abi.encodePacked(uint48(sVest.clf(id)), uint48(sVest.bgn(id)), usr)));
         assert(sVest.usr(id) == usr);
     }
     function mutcap(uint256 bump) private clock(90 days) {
         bump %= MAX;
         if (bump == 0) return;
         uint256 data = bump > MIN ? bump * WAD / TIME : MIN * WAD / TIME;
-        // Set DssVestSuckable cap slot n. 2 to override cap with data
-        hevm.store(address(sVest), bytes32(uint256(2)), bytes32(uint256(data)));
+        // Set DssVestSuckable cap slot to override cap with data
+        hevm.store(address(sVest), bytes32(uint256(CAP_MEMORY_SLOT)), bytes32(uint256(data)));
         assert(sVest.cap() == data);
     }
 }

--- a/echidna/DssVestTransferrableEchidnaTest.sol
+++ b/echidna/DssVestTransferrableEchidnaTest.sol
@@ -30,6 +30,11 @@ contract DssVestTransferrableEchidnaTest {
     uint256 internal constant  TIME     = 30 days;
     uint256 internal constant  MIN      = THOUSAND; // Initial cap amount
     uint256 internal constant  MAX      = MILLION;  // Max cap amount
+    uint256 internal constant  WARDS_MEMORY_SLOT    = 1;
+    uint256 internal constant  AWARDS_MEMORY_SLOT   = 2;
+    uint256 internal constant  CAP_MEMORY_SLOT      = 3;
+    uint256 internal constant  IDS_MEMORY_SLOT      = 4;
+    uint256 internal constant  LOCK_MEMORY_SLOT     = 5;
     uint256 internal immutable salt;                // initialTimestamp
 
     // Clock
@@ -143,9 +148,9 @@ contract DssVestTransferrableEchidnaTest {
             assert(tVest.commitments(bch) == false); // commitment must be false after
             _mutusr(id);
         } catch Error(string memory errmsg) {
-            bytes32 mLocked = hevm.load(address(tVest), bytes32(uint256(4)));      // Load memory slot 0x4
+            bytes32 tLocked = hevm.load(address(tVest), bytes32(uint256(LOCK_MEMORY_SLOT)));      // Load memory slot containing locked flag
             assert(
-                uint256(mLocked) == 1                                    && cmpStr(errmsg, "DssVest/system-locked")        ||
+                uint256(tLocked) == 1                                    && cmpStr(errmsg, "DssVest/system-locked")        ||
                 // authorization is not required for this function
                 // tVest.wards(address(this)) == 0                          && cmpStr(errmsg, "DssVest/not-authorized")       ||
                 usr == address(0)                                        && cmpStr(errmsg, "DssVest/invalid-user")         ||
@@ -189,7 +194,7 @@ contract DssVestTransferrableEchidnaTest {
             assert(tVest.res(id) == 1);
             _mutusr(id);
         } catch Error(string memory errmsg) {
-            bytes32 tLocked = hevm.load(address(tVest), bytes32(uint256(4)));      // Load memory slot 0x4
+            bytes32 tLocked = hevm.load(address(tVest), bytes32(uint256(LOCK_MEMORY_SLOT)));      // Load memory slot containing locked flag
             assert(
                 uint256(tLocked) == 1                                    && cmpStr(errmsg, "DssVest/system-locked")        ||
                 tVest.wards(address(this)) == 0                          && cmpStr(errmsg, "DssVest/not-authorized")       ||
@@ -252,7 +257,7 @@ contract DssVestTransferrableEchidnaTest {
             }
             assert(gem.totalSupply() == supplyBefore);
         } catch Error(string memory errmsg) {
-            bytes32 tLocked = hevm.load(address(tVest), bytes32(uint256(4)));      // Load memory slot 0x4
+            bytes32 tLocked = hevm.load(address(tVest), bytes32(uint256(LOCK_MEMORY_SLOT)));      // Load memory slot containing locked flag
             assert(
                 uint256(tLocked) == 1                                                 && cmpStr(errmsg, "DssVest/system-locked")       ||
                 award.usr == address(0)                                               && cmpStr(errmsg, "DssVest/invalid-award")       ||
@@ -309,7 +314,7 @@ contract DssVestTransferrableEchidnaTest {
             }
             assert(gem.totalSupply() == supplyBefore);
         } catch Error(string memory errmsg) {
-            bytes32 tLocked = hevm.load(address(tVest), bytes32(uint256(4)));      // Load memory slot 0x4
+            bytes32 tLocked = hevm.load(address(tVest), bytes32(uint256(LOCK_MEMORY_SLOT)));      // Load memory slot containing locked flag
             assert(
                 uint256(tLocked) == 1                                                 && cmpStr(errmsg, "DssVest/system-locked")       ||
                 award.usr == address(0)                                               && cmpStr(errmsg, "DssVest/invalid-award")       ||
@@ -339,7 +344,7 @@ contract DssVestTransferrableEchidnaTest {
         try tVest.restrict(id) {
             assert(tVest.res(id) == 1);
         } catch Error(string memory errmsg) {
-            bytes32 tLocked = hevm.load(address(tVest), bytes32(uint256(4)));      // Load memory slot 0x4
+            bytes32 tLocked = hevm.load(address(tVest), bytes32(uint256(LOCK_MEMORY_SLOT)));      // Load memory slot containing locked flag
             assert(
                 uint256(tLocked) == 1           && cmpStr(errmsg, "DssVest/system-locked") ||
                 tVest.usr(id) == address(0)     && cmpStr(errmsg, "DssVest/invalid-award") ||
@@ -356,7 +361,7 @@ contract DssVestTransferrableEchidnaTest {
         try tVest.unrestrict(id) {
             assert(tVest.res(id) == 0);
         } catch Error(string memory errmsg) {
-            bytes32 tLocked = hevm.load(address(tVest), bytes32(uint256(4)));      // Load memory slot 0x4
+            bytes32 tLocked = hevm.load(address(tVest), bytes32(uint256(LOCK_MEMORY_SLOT)));      // Load memory slot containing locked flag
             assert(
                uint256(tLocked) == 1           && cmpStr(errmsg, "DssVest/system-locked") ||
                tVest.usr(id) == address(0)     && cmpStr(errmsg, "DssVest/invalid-award") ||
@@ -391,7 +396,7 @@ contract DssVestTransferrableEchidnaTest {
                 }
             }
         } catch Error(string memory errmsg) {
-            bytes32 tLocked = hevm.load(address(tVest), bytes32(uint256(4)));      // Load memory slot 0x4
+            bytes32 tLocked = hevm.load(address(tVest), bytes32(uint256(LOCK_MEMORY_SLOT)));      // Load memory slot containing locked flag
             assert(
                 uint256(tLocked) == 1                                              && cmpStr(errmsg, "DssVest/system-locked")    ||
                 tVest.wards(address(this)) == 0 && mgr != address(this)            && cmpStr(errmsg, "DssVest/not-authorized")   ||
@@ -415,7 +420,7 @@ contract DssVestTransferrableEchidnaTest {
             assert(tVest.usr(id) == dst);
             _mutusr(id);
         } catch Error(string memory errmsg) {
-            bytes32 tLocked = hevm.load(address(tVest), bytes32(uint256(4)));      // Load memory slot 0x4
+            bytes32 tLocked = hevm.load(address(tVest), bytes32(uint256(LOCK_MEMORY_SLOT)));      // Load memory slot containing locked flag
             assert(
                 uint256(tLocked) == 1           && cmpStr(errmsg, "DssVest/system-locked")       ||
                 tVest.usr(id) != address(this)  && cmpStr(errmsg, "DssVest/only-user-can-move")  ||
@@ -429,17 +434,17 @@ contract DssVestTransferrableEchidnaTest {
     // --- Time-Based Fuzz Mutations ---
 
     function mutlock() private clock(1 hours) {
-        bytes32 tLocked = hevm.load(address(tVest), bytes32(uint256(4)));          // Load memory slot 0x4
+        bytes32 tLocked = hevm.load(address(tVest), bytes32(uint256(LOCK_MEMORY_SLOT)));          // Load memory slot 0x4
         uint256 locked = uint256(tLocked) == 0 ? 1 : 0;
-        // Set DssVestTransferrable locked slot n. 4 to override 0 with 1 and vice versa
-        hevm.store(address(tVest), bytes32(uint256(4)), bytes32(uint256(locked)));
-        tLocked = hevm.load(address(tVest), bytes32(uint256(4)));
+        // Set DssVestTransferrable locked slot to override 0 with 1 and vice versa
+        hevm.store(address(tVest), bytes32(uint256(LOCK_MEMORY_SLOT)), bytes32(uint256(locked)));
+        tLocked = hevm.load(address(tVest), bytes32(uint256(LOCK_MEMORY_SLOT)));
         assert(uint256(tLocked) == locked);
     }
     function mutauth() private clock(1 hours) {
         uint256 wards = tVest.wards(address(this)) == 1 ? 0 : 1;
-        // Set DssVestTransferrable wards slot n. 0 to override address(this) wards
-        hevm.store(address(tVest), keccak256(abi.encode(address(this), uint256(0))), bytes32(uint256(wards)));
+        // Set DssVestTransferrable wards slot to override address(this) wards
+        hevm.store(address(tVest), keccak256(abi.encode(address(this), uint256(WARDS_MEMORY_SLOT))), bytes32(uint256(wards)));
         assert(tVest.wards(address(this)) == wards);
     }
     function mutusr(uint256 id) private clock(1 days) {
@@ -449,16 +454,16 @@ contract DssVestTransferrableEchidnaTest {
     }
     function _mutusr(uint256 id) internal {
         address usr = tVest.usr(id) == address(this) ? address(0) : address(this);
-        // Set DssVestTrasferrable awards slot n. 1 (clf, bgn, usr) to override awards(id).usr with address(this)
-        hevm.store(address(tVest), keccak256(abi.encode(uint256(id), uint256(1))), bytesToBytes32(abi.encodePacked(uint48(tVest.clf(id)), uint48(tVest.bgn(id)), usr)));
+        // Set DssVestTrasferrable awards slot (clf, bgn, usr) to override awards(id).usr with address(this)
+        hevm.store(address(tVest), keccak256(abi.encode(uint256(id), uint256(AWARDS_MEMORY_SLOT))), bytesToBytes32(abi.encodePacked(uint48(tVest.clf(id)), uint48(tVest.bgn(id)), usr)));
         assert(tVest.usr(id) == usr);
     }
     function mutcap(uint256 bump) private clock(90 days) {
         bump %= MAX;
         if (bump == 0) return;
         uint256 data = bump > MIN ? bump * WAD / TIME : MIN * WAD / TIME;
-        // Set DssVestTransferrable cap slot n. 2 to override cap with data
-        hevm.store(address(tVest), bytes32(uint256(2)), bytes32(uint256(data)));
+        // Set DssVestTransferrable cap slot to override cap with data
+        hevm.store(address(tVest), bytes32(uint256(CAP_MEMORY_SLOT)), bytes32(uint256(data)));
         assert(tVest.cap() == data);
     }
 }

--- a/src/DssVest.sol
+++ b/src/DssVest.sol
@@ -64,11 +64,11 @@ abstract contract DssVest is ERC2771Context, Initializable {
 
     uint256 public ids; // Total vestings
 
-    mapping (bytes32 => bool) public commitments;
-
     uint256 internal locked;
 
     uint256 public constant  TWENTY_YEARS = 20 * 365 days;
+
+    mapping (bytes32 => bool) public commitments;
 
     // --- Events ---
     event Rely(address indexed usr);
@@ -229,7 +229,7 @@ abstract contract DssVest is ERC2771Context, Initializable {
         @param _mgr An optional manager for the contract. Can yank if vesting ends prematurely.
         @return id  The id of the vesting contract
     */
-    function create(address _usr, uint256 _tot, uint256 _bgn, uint256 _tau, uint256 _eta, address _mgr) external lock returns (uint256 id) {
+    function create(address _usr, uint256 _tot, uint256 _bgn, uint256 _tau, uint256 _eta, address _mgr) external lock auth returns (uint256 id) {
         return _create(_usr, _tot, _bgn, _tau, _eta, _mgr);
     }
 

--- a/test/DssVest.t.sol
+++ b/test/DssVest.t.sol
@@ -855,7 +855,7 @@ contract DssVestTest is DSTest {
     }
 
     function testWardsSlot0x1() public {
-        // Load memory slot 0x0
+        // Load memory slot 0x1
         bytes32 mWards = hevm.load(address(mVest), keccak256(abi.encode(address(this), uint256(1))));
         bytes32 sWards = hevm.load(address(sVest), keccak256(abi.encode(address(this), uint256(1))));
         bytes32 tWards = hevm.load(address(tVest), keccak256(abi.encode(address(this), uint256(1))));

--- a/test/DssVestLocal.t.sol
+++ b/test/DssVestLocal.t.sol
@@ -40,21 +40,4 @@ contract DssVestLocal is Test {
         vest.deny(ward);
         assertEq(vest.wards(ward), 0, "deny failed");
     }
-
-    function testReproduceCreateErrorLocal() public {
-        address usr = address(0xdeadbeef);
-        uint256 tot = 6;
-        uint256 bgn = block.timestamp - 10*365 days; //896401988;
-        uint256 tau = 29937;
-        uint256 eta = 1995;
-        address mgr = address(0);
-
-        uint256 cap = tot / tau;
-
-        DssVestMintable vest = new DssVestMintable(address(forwarder), address(this), cap);
-        console.log("block timestamp: %s", block.timestamp);
-        console.log("how long ago: %s", block.timestamp - bgn);
-        console.log("twenty years: %s", 20 * 365 days);
-        vest.create(usr, tot, bgn, tau, eta, mgr);
-    }
 }

--- a/test/DssVestLocal.t.sol
+++ b/test/DssVestLocal.t.sol
@@ -40,4 +40,21 @@ contract DssVestLocal is Test {
         vest.deny(ward);
         assertEq(vest.wards(ward), 0, "deny failed");
     }
+
+    function testReproduceCreateErrorLocal() public {
+        address usr = address(0xdeadbeef);
+        uint256 tot = 6;
+        uint256 bgn = block.timestamp - 10*365 days; //896401988;
+        uint256 tau = 29937;
+        uint256 eta = 1995;
+        address mgr = address(0);
+
+        uint256 cap = tot / tau;
+
+        DssVestMintable vest = new DssVestMintable(address(forwarder), address(this), cap);
+        console.log("block timestamp: %s", block.timestamp);
+        console.log("how long ago: %s", block.timestamp - bgn);
+        console.log("twenty years: %s", 20 * 365 days);
+        vest.create(usr, tot, bgn, tau, eta, mgr);
+    }
 }


### PR DESCRIPTION
Echidna still used the old storage layout and performed some manual read/write operations. This often caused tests to fail.

The storage layout changed because we inherit from `Initializable`.

Closes #38 