### PR TITLE
add parameter _amt to claimAndVest()

### DIFF
--- a/src/DssVest.sol
+++ b/src/DssVest.sol
@@ -321,10 +321,11 @@ abstract contract DssVest is ERC2771Context, Initializable {
         @param _eta The cliff duration in seconds (i.e. 1 years)
         @param _mgr An optional manager for the contract. Can yank if vesting ends prematurely.
         @param _slt The salt of the commitment
+        @param _amt The amount to vest. Use type(uint256).max to vest all.
     */
-    function claimAndVest(bytes32 _bch, address _usr, uint256 _tot, uint256 _bgn, uint256 _tau, uint256 _eta, address _mgr, bytes32 _slt) external returns (uint256 id) {
+    function claimAndVest(bytes32 _bch, address _usr, uint256 _tot, uint256 _bgn, uint256 _tau, uint256 _eta, address _mgr, bytes32 _slt, uint256 _amt) external returns (uint256 id) {
         id = claim(_bch, _usr, _tot, _bgn, _tau, _eta, _mgr, _slt);
-        _vest(id, type(uint256).max);
+        _vest(id, _amt);
     }
 
     /**


### PR DESCRIPTION
`_vest()` allows the user to choose how many tokens to vest. This choice is now possible with` claimAndVest()`, too