### PR TITLE
Feature/revoke commitments

### DIFF
--- a/src/DssVest.sol
+++ b/src/DssVest.sol
@@ -79,6 +79,7 @@ abstract contract DssVest is ERC2771Context, Initializable {
     event File(bytes32 indexed what, uint256 data);
 
     event Commit(bytes32 indexed hash);
+    event Revoke(bytes32 indexed hash);
     event Claim(bytes32 indexed hash, uint256 indexed id);
     event Init(uint256 indexed id, address indexed usr);
     event Vest(uint256 indexed id, uint256 amt);
@@ -216,7 +217,7 @@ abstract contract DssVest is ERC2771Context, Initializable {
     */
     function revoke(bytes32 bch) external lock auth {
         revocations[bch] = block.timestamp;
-        emit Commit(bch);
+        emit Revoke(bch);
     }
 
     /**
@@ -247,7 +248,7 @@ abstract contract DssVest is ERC2771Context, Initializable {
                 _tot = mul(_tot, sub(revocationTime, _bgn)) / _tau; // newTot as amount accrued if yanked at revocationTime
                 _tau = sub(revocationTime, _bgn); // new duration as time between bgn and revocationTime
                 commitments[_bch] = false;
-                id = _create(_usr, _tot, revocations[_bch], _tau, _eta, _mgr);
+                id = _create(_usr, _tot, _bgn, _tau, _eta, _mgr);
                 emit Claim(_bch, id);
             }
             else {

--- a/src/DssVest.sol
+++ b/src/DssVest.sol
@@ -242,8 +242,8 @@ abstract contract DssVest is ERC2771Context, Initializable {
         if ( revocationTime < _bgn + _eta  ) {
             // commitment has been revoked before the cliff: vesting plan is cancelled
             require(revocationTime == 0, "DssVest/commitment-revoked-before-cliff");
-        } else {
-            // commitment has been revoked after the cliff: vesting plan values have to be updated
+        } else if ( revocationTime < _bgn + _tau ) {
+            // commitment has been revoked after the cliff, but before the end: vesting plan values have to be updated
             // goal: behave as if the vesting plan was created when committed, and yanked when revoked
             _tot = mul(_tot, sub(revocationTime, _bgn)) / _tau; // newTot as amount accrued if yanked at revocationTime
             _tau = sub(revocationTime, _bgn); // new duration as time between bgn and revocationTime


### PR DESCRIPTION
closes #48 

Revoking a commitment changes how the `claim` is treated.
1. No revocation or revocation after end of the vesting plan: nothing changes
2. Revocation before cliff: claiming of commitment disabled
3. Revocation after the cliff, but before the end of the vesting plan: plan is updated to behave like it was yanked at revocation time.