### PR TITLE
enable partial claimAndVest, update deployment script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenize.it/dss-vest",
-  "version": "0.2.0-beta",
+  "version": "0.2.1-alpha",
   "description": "adds erc2771 and a factory for DssVestMintable to dss-vest",
   "keywords": [
     "evm",

--- a/script/DeployMintableFactory.s.sol
+++ b/script/DeployMintableFactory.s.sol
@@ -14,13 +14,18 @@ contract DeployMintableCloneFactory is Script {
 
         console.log("Deploying from: ", deployerAddress );
 
-        address forwarder = vm.envAddress("FORWARDER_GOERLI");
+        address forwarder = vm.envAddress("FORWARDER_MAINNET");
         address gem = address(0xdeadbeef);
         uint256 cap = 42 * 10 ** 18;
         
         vm.startBroadcast(deployerPrivateKey);
         DssVestMintable mintable = new DssVestMintable(forwarder, gem, cap);
         console.log("DssVestMintable logic contract deployed at: ", address(mintable));
+
+        console.log("Removing ward from logic contract. Deployer is ward: ", mintable.wards(deployerAddress));
+        mintable.deny(deployerAddress);
+        console.log("Logic contract still has ward: ", mintable.wards(deployerAddress));
+
         
         DssVestMintableCloneFactory factory = new DssVestMintableCloneFactory(address(mintable));
         console.log("DssVestMintableCloneFactory deployed at: ", address(factory));

--- a/src/DssVest.sol
+++ b/src/DssVest.sol
@@ -321,10 +321,11 @@ abstract contract DssVest is ERC2771Context, Initializable {
         @param _eta The cliff duration in seconds (i.e. 1 years)
         @param _mgr An optional manager for the contract. Can yank if vesting ends prematurely.
         @param _slt The salt of the commitment
+        @param _amt The amount to vest. Use type(uint256).max to vest all.
     */
-    function claimAndVest(bytes32 _bch, address _usr, uint256 _tot, uint256 _bgn, uint256 _tau, uint256 _eta, address _mgr, bytes32 _slt) external returns (uint256 id) {
+    function claimAndVest(bytes32 _bch, address _usr, uint256 _tot, uint256 _bgn, uint256 _tau, uint256 _eta, address _mgr, bytes32 _slt, uint256 _amt) external returns (uint256 id) {
         id = claim(_bch, _usr, _tot, _bgn, _tau, _eta, _mgr, _slt);
-        _vest(id, type(uint256).max);
+        _vest(id, _amt);
     }
 
     /**

--- a/test/DssVestBlind.t.sol
+++ b/test/DssVestBlind.t.sol
@@ -309,7 +309,7 @@ contract DssVestLocal is Test {
         assertTrue(gem.balanceOf(usr) == _tot, "balance is not equal to total");
     }
 
-    function testRevokeAndYankBehaveEqual( uint48 _tau, uint48 _eta, uint128 _tot,  uint48 revokeAfter) public {
+    function testRevokeAndYankBehaveEqualLocal( uint48 _tau, uint48 _eta, uint128 _tot,  uint48 revokeAfter) public {
         // uint128 _tot = 8127847e18;
         uint48 _bgn = 60 * 365 days;
         bytes32 _slt = 0;
@@ -356,14 +356,14 @@ contract DssVestLocal is Test {
             console.log("User gets no tokens, so claim must fail");
             vm.prank(usrCommit);
             vm.expectRevert(); // "DssVest/no-vest-total-amount" or "DssVest/commitment-revoked-before-cliff"
-            vest.claimAndVest(hash, usrCommit, _tot, _bgn, _tau, _eta, ward, _slt);
+            vest.claimAndVest(hash, usrCommit, _tot, _bgn, _tau, _eta, ward, _slt, type(uint256).max);
             // assure no vesting plan has been created
             assertTrue(vest.ids() == planId, "a vesting plan has been created");
         }
         else {
             console.log("User gets tokens");
             vm.prank(usrCommit);
-            vest.claimAndVest(hash, usrCommit, _tot, _bgn, _tau, _eta, ward, _slt);
+            vest.claimAndVest(hash, usrCommit, _tot, _bgn, _tau, _eta, ward, _slt, type(uint256).max);
 
             console.log("usrCommit balance: ", gem.balanceOf(usrCommit));
             // check correct execution

--- a/test/DssVestBlind.t.sol
+++ b/test/DssVestBlind.t.sol
@@ -244,14 +244,14 @@ contract DssVestLocal is Test {
             console.log("newTot is 0");
             vm.prank(usr);
             vm.expectRevert("DssVest/no-vest-total-amount");
-            vest.claimAndVest(hash, usr, _tot, _bgn, _tau, _eta, ward, _slt);
+            vest.claimAndVest(hash, usr, _tot, _bgn, _tau, _eta, ward, _slt, type(uint256).max);
             // assure no vesting plan has been created
             assertTrue(vest.ids() == 0, "a vesting plan has been created");
         }
         else {
             console.log("newTot is not 0");
             vm.prank(usr);
-            vest.claimAndVest(hash, usr, _tot, _bgn, _tau, _eta, ward, _slt);
+            vest.claimAndVest(hash, usr, _tot, _bgn, _tau, _eta, ward, _slt, type(uint256).max);
             // check correct execution
             assertTrue(vest.commitments(hash) == false, "commitment still exists");
             assertTrue(vest.revocations(hash) == _bgn + revokeAfter, "revocation not correct");
@@ -297,7 +297,7 @@ contract DssVestLocal is Test {
         vm.warp(uint256(_bgn) + uint256(_tau) + 1);
 
         vm.prank(usr);
-        vest.claimAndVest(hash, usr, _tot, _bgn, _tau, _eta, ward, _slt);
+        vest.claimAndVest(hash, usr, _tot, _bgn, _tau, _eta, ward, _slt, type(uint256).max);
         // check correct execution
         assertTrue(vest.commitments(hash) == false, "commitment still exists");
         assertTrue(vest.revocations(hash) == _bgn + revokeAfter, "revocation not correct");


### PR DESCRIPTION
- `claimAndVest(id, amount)` enables claiming of blind commtiments and partial (or complete)  vesting of tokens in one transactions. Before, on complete vesting of the tokens was possible. See #49, which is included in this PR because #49 wasn't merged in time.
- deployment script leaves the logic contract contract in an initialized state where it is not controlled by anyone (no wards left). 
