### PR TITLE
Feature/disable initializers

### DIFF
--- a/src/DssVest.sol
+++ b/src/DssVest.sol
@@ -139,7 +139,7 @@ abstract contract DssVest is ERC2771Context, Initializable {
         @param _ward The address to be granted admin rights to the contract
         @param _cap The maximum per-second issuance token rate
      */
-    function initialize(address _ward, uint256 _cap) public onlyInitializing { 
+    function initialize(address _ward, uint256 _cap) internal onlyInitializing { 
         wards[_ward] = 1;
         emit Rely(_ward);
         cap = _cap;

--- a/src/DssVest.sol
+++ b/src/DssVest.sol
@@ -127,7 +127,7 @@ abstract contract DssVest is ERC2771Context, Initializable {
         @param _cap The maximum per-second issuance token rate
     */
     constructor (address _trustedForwarder, uint256 _cap) ERC2771Context(_trustedForwarder) initializer {
-        initialize(_msgSender(), _cap);   
+        initialize(_msgSender(), _cap); 
     }
 
     /**
@@ -523,7 +523,8 @@ contract DssVestMintable is DssVest {
         @param _cap The maximum amount of token bits that can be released in one plan each second
     */
     constructor(address _forwarder, address _gem, uint256 _cap) DssVest(_forwarder, _cap) {
-        initialize(_gem, _msgSender(), _cap);   
+        initialize(_gem, _msgSender(), _cap); 
+        _disableInitializers();  
     }
 
     function initialize(address _gem, address _ward, uint256 _cap) initializer public {
@@ -558,6 +559,7 @@ contract DssVestSuckable is DssVest {
     */
     constructor(address _forwarder, address _chainlog, uint256 _cap) DssVest(_forwarder, _cap) {
         initialize(_chainlog, _msgSender(), _cap);
+        _disableInitializers();
     }
 
     function initialize(address _chainlog, address _ward, uint256 _cap) initializer public {
@@ -600,7 +602,8 @@ contract DssVestTransferrable is DssVest {
         @param _cap The maximum amount of token bits that can be released in one plan each second
     */
     constructor(address _forwarder, address _czar, address _gem, uint256 _cap) DssVest(_forwarder, _cap) {
-        initialize(_czar, _gem, _msgSender(), _cap);    
+        initialize(_czar, _gem, _msgSender(), _cap);
+        _disableInitializers();    
     }
 
     function initialize(address _czar, address _gem, address _ward, uint256 _cap) initializer public {


### PR DESCRIPTION
Minor changes to make the cloning safer.
https://docs.openzeppelin.com/contracts/4.x/api/proxy#Initializable-_disableInitializers--