### PR TITLE
Feature/create unrestricted

### DIFF
--- a/src/DssVest.sol
+++ b/src/DssVest.sol
@@ -268,6 +268,22 @@ abstract contract DssVest is ERC2771Context, Initializable {
         return _create(_usr, _tot, _bgn, _tau, _eta, _mgr);
     }
 
+    /**
+        @dev Governance adds a vesting contract that can be vested by anyone
+        @param _usr The recipient of the reward
+        @param _tot The total amount of the vest
+        @param _bgn The starting timestamp of the vest
+        @param _tau The duration of the vest (in seconds)
+        @param _eta The cliff duration in seconds (i.e. 1 years)
+        @param _mgr An optional manager for the contract. Can yank if vesting ends prematurely.
+        @return id  The id of the vesting contract
+    */
+    function createUnrestricted(address _usr, uint256 _tot, uint256 _bgn, uint256 _tau, uint256 _eta, address _mgr) external lock auth returns (uint256 id) {
+        uint256 _id = _create(_usr, _tot, _bgn, _tau, _eta, _mgr);
+        awards[_id].res = 0;
+        return id;
+    }
+
 
     /**
         @dev Governance adds a vesting contract

--- a/src/DssVest.sol
+++ b/src/DssVest.sol
@@ -281,7 +281,7 @@ abstract contract DssVest is ERC2771Context, Initializable {
     function createUnrestricted(address _usr, uint256 _tot, uint256 _bgn, uint256 _tau, uint256 _eta, address _mgr) external lock auth returns (uint256 id) {
         uint256 _id = _create(_usr, _tot, _bgn, _tau, _eta, _mgr);
         awards[_id].res = 0;
-        return id;
+        return _id;
     }
 
 

--- a/test/DssVestClone.t.sol
+++ b/test/DssVestClone.t.sol
@@ -67,6 +67,8 @@ contract DssVestCloneDemo is Test {
     bytes32 r;
     bytes32 s;
 
+    uint256 days_vest = 10**18;
+
     function setUp() public {
 
         vm.warp(60 * 365 days); // in local testing, the time would start at 1. This causes problems with the vesting contract. So we warp to 60 years.
@@ -432,6 +434,8 @@ contract DssVestCloneDemo is Test {
 
     function testNoWrongWardsLocal(bytes32 salt, address localCompanyAdmin, uint256 newCap) public {
         vm.assume(localCompanyAdmin != address(this));
+        vm.assume(localCompanyAdmin != platformAdminAddress);
+        vm.assume(localCompanyAdmin != address(mintableFactory));
 
         vm.startPrank(platformAdminAddress);
         Token localCompanyToken = new Token(
@@ -507,5 +511,58 @@ contract DssVestCloneDemo is Test {
         assertEq(localCompanyToken.balanceOf(employeeAddress), totalVestAmount * timeShift / vestDuration, "employee has received wrong token amount");
     }
     
+    function testCreateUnrestrictedTransferrableLocal(address _usr, address rando, bytes32 salt) public {
+        vm.assume(_usr != address(0));
+        vm.assume(rando != address(0));
+
+        ERC20MintableByAnyone gem = new ERC20MintableByAnyone("gem", "GEM");
+
+        // predict clone address
+        address expectedAddress = transferrableFactory.predictCloneAddress(salt);
+
+        // Deploy clone
+        DssVestTransferrable tVest = DssVestTransferrable(
+            transferrableFactory.createTransferrableVestingClone(salt, expectedAddress, address(gem), address(this), 10**18));
+
+        // mint necessary tokens
+        gem.mint(address(tVest), 100 * days_vest);
+
+        uint256 id = tVest.createUnrestricted(_usr, 100 * days_vest, block.timestamp, 100 days, 0 days, address(0));
+
+        assertEq(tVest.res(id), 0, "Award is restricted");
+
+        vm.warp(block.timestamp + 10 days);
+
+        (address usr, uint48 bgn, uint48 clf, uint48 fin,,, uint128 tot, uint128 rxd) = tVest.awards(id);
+        assertEq(usr, _usr);
+        assertEq(uint256(bgn), block.timestamp - 10 days);
+        assertEq(uint256(fin), block.timestamp + 90 days);
+        assertEq(uint256(tot), 100 * days_vest);
+        assertEq(uint256(rxd), 0);
+        assertEq(gem.balanceOf(_usr), 0);
+
+        // anyone can vest this unrestricted award
+        vm.prank(rando);
+        tVest.vest(id);
+        (usr, bgn, clf, fin,,, tot, rxd) = tVest.awards(id);
+        assertEq(usr, _usr);
+        assertEq(uint256(bgn), block.timestamp - 10 days);
+        assertEq(uint256(fin), block.timestamp + 90 days);
+        assertEq(uint256(tot), 100 * days_vest);
+        assertEq(uint256(rxd), 10 * days_vest);
+        assertEq(gem.balanceOf(_usr), 10 * days_vest);
+
+        vm.warp(block.timestamp + 70 days);
+
+        vm.prank(rando);
+        tVest.vest(id, type(uint256).max);
+        (usr, bgn, clf, fin,,, tot, rxd) = tVest.awards(id);
+        assertEq(usr, _usr);
+        assertEq(uint256(bgn), block.timestamp - 80 days);
+        assertEq(uint256(fin), block.timestamp + 20 days);
+        assertEq(uint256(tot), 100 * days_vest);
+        assertEq(uint256(rxd), 80 * days_vest);
+        assertEq(gem.balanceOf(_usr), 80 * days_vest);
+    }
     
 }

--- a/test/DssVestLocal.t.sol
+++ b/test/DssVestLocal.t.sol
@@ -10,7 +10,7 @@ import "@openzeppelin/contracts/proxy/Proxy.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/proxy/Clones.sol";
-import {DssVestMintable} from "../src/DssVest.sol";
+import {DssVestMintable, DssVestTransferrable} from "../src/DssVest.sol";
 import "./resources/ERC20MintableByAnyone.sol";
 
 contract DssVestLocal is Test {
@@ -49,8 +49,9 @@ contract DssVestLocal is Test {
         vest.create(address(2), 1, 1, 1, 1, address(0));
     }
 
-    function testCreateUnrestricted(address _usr) public {
+    function testCreateUnrestrictedMintableLocal(address _usr, address rando) public {
         vm.assume(_usr != address(0));
+        vm.assume(rando != address(0));
 
         uint256 days_vest = 10**18;
         ERC20MintableByAnyone gem = new ERC20MintableByAnyone("gem", "GEM");
@@ -71,6 +72,8 @@ contract DssVestLocal is Test {
         assertEq(uint256(rxd), 0);
         assertEq(gem.balanceOf(_usr), 0);
 
+        // anyone can vest this unrestricted award
+        vm.prank(rando);
         mVest.vest(id);
         (usr, bgn, clf, fin, mgr,, tot, rxd) = mVest.awards(id);
         assertEq(usr, _usr);
@@ -82,6 +85,7 @@ contract DssVestLocal is Test {
 
         vm.warp(block.timestamp + 70 days);
 
+        vm.prank(rando);
         mVest.vest(id, type(uint256).max);
         (usr, bgn, clf, fin, mgr,, tot, rxd) = mVest.awards(id);
         assertEq(usr, _usr);

--- a/test/DssVestLocal.t.sol
+++ b/test/DssVestLocal.t.sol
@@ -11,6 +11,7 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/proxy/Clones.sol";
 import {DssVestMintable} from "../src/DssVest.sol";
+import "./resources/ERC20MintableByAnyone.sol";
 
 contract DssVestLocal is Test {
     // init forwarder
@@ -46,5 +47,48 @@ contract DssVestLocal is Test {
         vm.expectRevert("DssVest/not-authorized");
         vm.prank(noWard);
         vest.create(address(2), 1, 1, 1, 1, address(0));
+    }
+
+    function testCreateUnrestricted(address _usr) public {
+        vm.assume(_usr != address(0));
+
+        uint256 days_vest = 10**18;
+        ERC20MintableByAnyone gem = new ERC20MintableByAnyone("gem", "GEM");
+
+        DssVestMintable mVest = new DssVestMintable(address(forwarder), address(gem), 10**18);
+
+        uint256 id = mVest.createUnrestricted(_usr, 100 * days_vest, block.timestamp, 100 days, 0 days, address(0));
+
+        assertEq(mVest.res(id), 0, "Award is restricted");
+
+        vm.warp(block.timestamp + 10 days);
+
+        (address usr, uint48 bgn, uint48 clf, uint48 fin, address mgr,, uint128 tot, uint128 rxd) = mVest.awards(id);
+        assertEq(usr, _usr);
+        assertEq(uint256(bgn), block.timestamp - 10 days);
+        assertEq(uint256(fin), block.timestamp + 90 days);
+        assertEq(uint256(tot), 100 * days_vest);
+        assertEq(uint256(rxd), 0);
+        assertEq(gem.balanceOf(_usr), 0);
+
+        mVest.vest(id);
+        (usr, bgn, clf, fin, mgr,, tot, rxd) = mVest.awards(id);
+        assertEq(usr, _usr);
+        assertEq(uint256(bgn), block.timestamp - 10 days);
+        assertEq(uint256(fin), block.timestamp + 90 days);
+        assertEq(uint256(tot), 100 * days_vest);
+        assertEq(uint256(rxd), 10 * days_vest);
+        assertEq(gem.balanceOf(_usr), 10 * days_vest);
+
+        vm.warp(block.timestamp + 70 days);
+
+        mVest.vest(id, type(uint256).max);
+        (usr, bgn, clf, fin, mgr,, tot, rxd) = mVest.awards(id);
+        assertEq(usr, _usr);
+        assertEq(uint256(bgn), block.timestamp - 80 days);
+        assertEq(uint256(fin), block.timestamp + 20 days);
+        assertEq(uint256(tot), 100 * days_vest);
+        assertEq(uint256(rxd), 80 * days_vest);
+        assertEq(gem.balanceOf(_usr), 80 * days_vest);
     }
 }


### PR DESCRIPTION
With restricted vesting plans, users need to vest tokens themselves. This is not always desirable. A new function `createUnrestricted()` now offers the option to create vesting plans that are immediately unrestricted, so anyone can vest the tokens for the user.